### PR TITLE
Add instant splash screen with 2-second display duration

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import { StandingsProvider } from '@/contexts/StandingsContext';
 import { OnboardingModal } from '@/components/onboarding/OnboardingModal';
 import { AuthModal } from '@/components/auth/AuthModal';
 import { useAuth } from '@/contexts/AuthContext';
+import { SplashScreenComponent } from '@/components/SplashScreenComponent';
 import './globals.css';
 
 SplashScreen.preventAutoHideAsync();
@@ -88,6 +89,7 @@ function AppContent() {
 }
 
 export default function RootLayout() {
+  const [showSplash, setShowSplash] = useState(true);
   const [fontsLoaded, fontError] = useFonts({
     'Formula1-Bold': require('../assets/fonts/Formula1-Bold_web_0.ttf'),
     'Formula1-Regular': require('../assets/fonts/Formula1-Regular_web_0.ttf'),
@@ -105,10 +107,15 @@ export default function RootLayout() {
   }
 
   return (
-    <AuthProvider>
-      <StandingsProvider>
-        <AppContent />
-      </StandingsProvider>
-    </AuthProvider>
+    <>
+      <AuthProvider>
+        <StandingsProvider>
+          <AppContent />
+        </StandingsProvider>
+      </AuthProvider>
+      
+      {/* Splash Screen - Renders at top level for immediate display */}
+      {showSplash && <SplashScreenComponent onFinish={() => setShowSplash(false)} />}
+    </>
   );
 }

--- a/components/SplashScreenComponent.tsx
+++ b/components/SplashScreenComponent.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { View, Image, StyleSheet, Animated } from 'react-native';
+
+interface SplashScreenComponentProps {
+  onFinish: () => void;
+}
+
+export const SplashScreenComponent: React.FC<SplashScreenComponentProps> = ({ onFinish }) => {
+  const [fadeAnim] = useState(new Animated.Value(1)); // Start at full opacity
+
+  useEffect(() => {
+    // Auto-hide after 2 seconds with fade out
+    const timer = setTimeout(() => {
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => {
+        onFinish();
+      });
+    }, 1700); // 1.7 seconds visible + 0.3s fade out = 2 seconds total
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
+      <Image
+        source={require('@/assets/images/splash.png')}
+        style={styles.image}
+        resizeMode="cover"
+      />
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#000000',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 9999,
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a top-level animated splash screen that overlays the app and auto-hides after ~2 seconds.
> 
> - **UI**:
>   - **Splash screen overlay**: Add `components/SplashScreenComponent` with full-screen image and 300ms fade-out, auto-hiding after ~2s via `onFinish`.
>   - **Root layout**: Render splash at top level in `app/_layout.tsx` using `showSplash` state; import component and wrap providers in a fragment to overlay content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81d7945a689c3d73c3050ae4b5a73cc7b7114bcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->